### PR TITLE
fixing so only inferred 'undef' is overwritten

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -802,14 +802,14 @@ function handleAssignmentExpressionType(scope,exprNode,targetNode,sourceNode) {
 	// target is simple identifier?
 	if (T.isIdentifier(targetNode)) {
 		let targetBinding = scope.getBinding(targetNode.name);
-    
+
 		if (targetBinding) {
 			let targetType = nodeTypes.get(targetBinding);
 			let targetSignature = typeSignatures.get(targetBinding);
 			let sourceType = nodeTypes.get(sourceNode);
+			let sourceTypeID = getTypeID(sourceType);
 			let sourceSignature = typeSignatures.get(sourceNode);
-      
-      
+
 			// source expression has a recognized type?
 			if (sourceType && getTypeID(sourceType) != "unknown") {
 				if (exprNode) {
@@ -818,10 +818,21 @@ function handleAssignmentExpressionType(scope,exprNode,targetNode,sourceNode) {
 				// target already has an implied type?
 				if (targetType) {
 					if (!typesMatch(targetType,sourceType)) {
-            if(getTypeID(targetType) == "undef"){
-              nodeTypes.set(targetBinding, sourceType)
-            }
-						reportUnexpectedType("Assignment type mismatch",targetType,sourceType);
+						if (targetType.inferred == "undef"){
+							delete targetType.inferred;
+							Object.assign(targetType,sourceType);
+
+							// NOTE: temporary debugging output
+							if (isTaggedType(sourceType)) {
+								console.log(`Re-implying ${targetNode.name} with tagged-type '${sourceTypeID}'`);
+							}
+							else {
+								console.log(`Re-implying ${targetNode.name} to inferred-type '${sourceTypeID}'`);
+							}
+						}
+						else {
+							reportUnexpectedType("Assignment type mismatch",targetType,sourceType);
+						}
 					}
 					else if (targetSignature) {
 						if (!signaturesMatch(sourceSignature,targetSignature)) {


### PR DESCRIPTION
We only want to overwrite `undef` type if it was inferred. If you explicitly tag `undef`, then you're saying you only want that in there.